### PR TITLE
style: format installer.ts with oxfmt

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34674,9 +34674,7 @@ function verifyChecksum(path, expectedChecksum) {
     if (!/^[a-f0-9]{64}$/.test(normalizedExpected)) {
         throw new Error("The checksum input must be a SHA256 hex digest.");
     }
-    const actualChecksum = (0,external_node_crypto_.createHash)("sha256")
-        .update((0,external_node_fs_namespaceObject.readFileSync)(path))
-        .digest("hex");
+    const actualChecksum = (0,external_node_crypto_.createHash)("sha256").update((0,external_node_fs_namespaceObject.readFileSync)(path)).digest("hex");
     if (actualChecksum !== normalizedExpected) {
         throw new Error(`Downloaded Task archive checksum mismatch. Expected ${normalizedExpected}, got ${actualChecksum}.`);
     }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -154,9 +154,7 @@ function verifyChecksum(path: string, expectedChecksum?: string): void {
     throw new Error("The checksum input must be a SHA256 hex digest.");
   }
 
-  const actualChecksum = createHash("sha256")
-    .update(readFileSync(path))
-    .digest("hex");
+  const actualChecksum = createHash("sha256").update(readFileSync(path)).digest("hex");
   if (actualChecksum !== normalizedExpected) {
     throw new Error(
       `Downloaded Task archive checksum mismatch. Expected ${normalizedExpected}, got ${actualChecksum}.`,
@@ -164,10 +162,7 @@ function verifyChecksum(path: string, expectedChecksum?: string): void {
   }
 }
 
-async function downloadRelease(
-  version: string,
-  checksum?: string,
-): Promise<string> {
+async function downloadRelease(version: string, checksum?: string): Promise<string> {
   // Download
   const fileName: string = getFileName();
   const downloadUrl: string = format(


### PR DESCRIPTION
## Summary

`oxfmt --check` failed on `src/installer.ts`, which was still formatted with the old line-breaking style. Ran `oxfmt --write` on the repo and rebuilt the bundle so `dist/index.js` matches the source.

## Test plan

Existing vitest suite passes, `npx oxfmt --check .` is clean, and `dist` is regenerated with `npx tsc && npx ncc build` so the CI dist-up-to-date check stays green. No behaviour change — whitespace only.